### PR TITLE
 [Issue #12] Command to cycle encryption keys.

### DIFF
--- a/app/Console/Commands/CycleEncryptionCommand.php
+++ b/app/Console/Commands/CycleEncryptionCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Contact;
+use Illuminate\Foundation\Console\KeyGenerateCommand;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class CycleEncryptionCommand extends KeyGenerateCommand
+{
+
+    public $classesWithEncryption = [
+        \App\Contact::class,
+    ];
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'key:cycle';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sets a new application key and re-encrypts the database data';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $oldKey = config('app.key');
+        $this->info("Old key is {$oldKey}");
+        $key = $this->generateRandomKey();
+        $this->info("New key is {$key}");
+
+        DB::beginTransaction();
+        try {
+            foreach ($this->classesWithEncryption as $class) {
+                $this->cycleEncryption($class, $key, $oldKey);
+            }
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            $this->error(
+                "There was an error cycling the encryption of the database data. Nothing was modified");
+            $this->error("Error message: {$e->getMessage()}");
+            return;
+        }
+        config(['app.key' => $key]);
+        DB::commit();
+
+
+        $this->setKeyInEnvironmentFile($key);
+
+
+        $this->info("Application key [$key] replaced successfully.");
+    }
+
+
+    public function cycleEncryption($class, $key, $oldKey)
+    {
+        if (!in_array(\App\EncryptsFields::class, class_uses($class))) {
+            return;
+        }
+
+        $entries = (new $class())->all();
+
+        $progress = new ProgressBar($this->output, $entries->count());
+        $this->info("Re-encrypting {$class}");
+        $progress->start();
+
+        $entries->each(function ($entry) use ($progress, $oldKey, $key) {
+            foreach ($entry->encryptable as $field) {
+                $value = $entry->getAttribute($field);
+                $entry->setAttribute($field, $value);
+            }
+            $entry->save();
+            $progress->advance();
+        });
+        $progress->finish();
+        $this->line("\n");
+        $this->info("Successfully re-encrypted {$class}");
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        \App\Console\Commands\CycleEncryptionCommand::class,
     ];
 
     /**

--- a/app/Contact.php
+++ b/app/Contact.php
@@ -7,9 +7,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class Contact extends Model
 {
-//    use EncryptsFields;
+    use EncryptsFields;
 
-//    protected $encryptable = ['name', 'email', 'phone'];
+    public $encryptable = ['name', 'email', 'phone'];
 
     protected $fillable = ['name', 'email', 'phone', 'zip', 'campaign', 'source', 'topics'];
 

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -27,7 +27,7 @@ $factory->define(App\Contact::class, function (Faker\Generator $faker) {
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,
         'phone' => $faker->phoneNumber,
-        'zip' => $faker->postcode,
+        'zip' => $faker->randomNumber(5),
         'campaign' => $faker->userName,
         'topics' => [$faker->sentence, $faker->sentence],
         'source' => $faker->tld,

--- a/tests/Console/Commands/CycleEncryptionTest.php
+++ b/tests/Console/Commands/CycleEncryptionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Console\Commands\CycleEncryptionCommand;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Mockery as m;
+
+class CycleEncryptionTest extends TestCase
+{
+
+    use DatabaseMigrations;
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct();
+    }
+
+
+    function test_it_sets_a_new_app_key()
+    {
+        $oldKey = config('app.key');
+
+        Artisan::call('key:cycle');
+
+        $this->assertNotEquals($oldKey, config('app.key'));
+    }
+
+    function test_it_saves_new_encrypted_values_to_the_database()
+    {
+        $user = factory(App\Contact::class)->create();
+
+        Artisan::call('key:cycle');
+
+        $reEncryptedUser = App\Contact::find($user->id);
+
+        foreach ($user->encryptable as $field) {
+            $this->assertNotEquals($user->getOriginal($field), $reEncryptedUser->getOriginal($field));
+            $this->assertEquals($user->getAttribute($field), $reEncryptedUser->getAttribute($field));
+        }
+    }
+
+    function test_it_does_not_save_anything_when_an_exception_occurs()
+    {
+
+        // Need to find a way to assess the following:
+        // DB::shouldReceive('beginTransaction')->once();
+        // DB::shouldReceive('rollBack')->once();
+        // DB::shouldNotReceive('commit');
+
+
+    }
+
+    function test_it_skips_when_a_model_does_not_use_encryption()
+    {
+        $eloquentModel = new m\Mock(Illuminate\Database\Eloquent::class);
+        $eloquentModel->shouldNotReceive('every', 'getArgument', 'setArgument');
+
+        (new CycleEncryptionCommand())->cycleEncryption(get_class($eloquentModel), 'key', 'oldKey');
+
+
+    }
+}

--- a/tests/Console/Commands/CycleEncryptionTest.php
+++ b/tests/Console/Commands/CycleEncryptionTest.php
@@ -14,7 +14,6 @@ class CycleEncryptionTest extends TestCase
         parent::__construct();
     }
 
-
     function test_it_sets_a_new_app_key()
     {
         $oldKey = config('app.key');
@@ -40,13 +39,10 @@ class CycleEncryptionTest extends TestCase
 
     function test_it_does_not_save_anything_when_an_exception_occurs()
     {
-
         // Need to find a way to assess the following:
         // DB::shouldReceive('beginTransaction')->once();
         // DB::shouldReceive('rollBack')->once();
         // DB::shouldNotReceive('commit');
-
-
     }
 
     function test_it_skips_when_a_model_does_not_use_encryption()
@@ -54,8 +50,6 @@ class CycleEncryptionTest extends TestCase
         $eloquentModel = new m\Mock(Illuminate\Database\Eloquent::class);
         $eloquentModel->shouldNotReceive('every', 'getArgument', 'setArgument');
 
-        (new CycleEncryptionCommand())->cycleEncryption(get_class($eloquentModel), 'key', 'oldKey');
-
-
+        (new CycleEncryptionCommand())->cycleEncryption(get_class($eloquentModel));
     }
 }


### PR DESCRIPTION
## This is a pull request for issue #12 - Need a command to cycle encryption keys.

I created a new `php artisan key:cycle` command that implements the flow described in the issue : 

> * Generate a second encryption key.
> * Foreach contact, decrypt all of their data with the old key and re-encrypt it with the new key
> * Afterwards, delete the old key and move the new key to be the "primary" key

I'm using a database transactions to only commit the changes when no exceptions were raised in the process. However I could not find a way to test it with **phpunit**and I'm open to ideas on how to implement it.
See `CycleEncryptionTest::test_it_does_not_save_anything_when_an_exception_occurs`.

I also write the old and new keys to stdout. It gives me peace of mind to have a written trace of the 2 keys in case something goes wrong, but it should probably be dropped in production since it's a massive security risk. Thoughts?

I had to change the zip code format in the contacts model factory to a simple random 5 digits number. It's fine if the the platform is only used within the US, but it will throw an error with a bunch of non-US non-digit based postal codes (like Canada or UK). Maybe we should change the migration to something a bit more lenient? By the way, shouldn't the zip code also be encrypted? 

Final point, I don't know if the whole Auth system is currently being used, but any user password will be rendered bogus by this command.  